### PR TITLE
Allow editing user with no RFID tag

### DIFF
--- a/front-end-pages/admin-pages/members-tab/member-edit/admin-members-edit.html
+++ b/front-end-pages/admin-pages/members-tab/member-edit/admin-members-edit.html
@@ -65,7 +65,7 @@ function isSelected($option, $target) {
 
                         <div class="form-group">
                             <label for="rfidNumber" class="control-label">RFID Number</label>
-                            <input required name="rfidNumber" class="form-control" value="<?php echo $user->getCustomSchemas()['roles']['rfid-id'];?>">
+                            <input name="rfidNumber" class="form-control" value="<?php echo $user->getCustomSchemas()['roles']['rfid-id'];?>">
                         </div>
 
                         <div class="form-group">

--- a/front-end-pages/admin-pages/members-tab/member-edit/admin-members-edit.html
+++ b/front-end-pages/admin-pages/members-tab/member-edit/admin-members-edit.html
@@ -18,6 +18,11 @@ $status = $user->getCustomSchemas()['Subscription_Management']['Subscription_Sta
 $expDate = $user->getCustomSchemas()['Subscription_Management']['Subscription_Expiration'];
 $stripeID = $user->getCustomSchemas()['Subscription_Management']['Stripe_ID'];
 
+$rfid = $user->getCustomSchemas()['roles']['rfid-id'];
+if ($rfid == 0) {
+    $rfid = "";
+}
+
 $personalEmail = $user->getEmails()[0]['address'];
 $dm_email = $user->getPrimaryEmail();
 
@@ -65,7 +70,7 @@ function isSelected($option, $target) {
 
                         <div class="form-group">
                             <label for="rfidNumber" class="control-label">RFID Number</label>
-                            <input name="rfidNumber" class="form-control" value="<?php echo $user->getCustomSchemas()['roles']['rfid-id'];?>">
+                            <input name="rfidNumber" class="form-control" value="<?php echo $rfid;?>">
                         </div>
 
                         <div class="form-group">

--- a/front-end-pages/admin-pages/members-tab/member-table/admin-member-data.php
+++ b/front-end-pages/admin-pages/members-tab/member-table/admin-member-data.php
@@ -28,6 +28,11 @@ if (count($results->getUsers()) != 0) {
         $type = !empty($sub_mgmt["Subscription_Type"]) ? $sub_mgmt["Subscription_Type"] : '';
         $stripe_id = !empty($sub_mgmt["Stripe_ID"]) ? $sub_mgmt["Stripe_ID"] : '';
 
+        # Treat 0 as "empty" value, since deleting the rfid_id from G Suite doesn't work
+        if ($rfid_tag == 0) {
+            $rfid_tag = "";
+        }
+
         # Default Google Fields to use
         $name = $user->getName()->getFullName();
         $email = $user->getPrimaryEmail();

--- a/postable/admin-member-edit.php
+++ b/postable/admin-member-edit.php
@@ -34,7 +34,7 @@ function prefix_admin_update_member() {
     if (!empty($rfidNumber)) {
         $properties['customSchemas']['roles']['rfid-id'] = $rfidNumber;
     } else {
-        $properties['customSchemas']['roles']['rfid-id'] = null;
+        $properties['customSchemas']['roles']['rfid-id'] = 0;
     }
     $properties['customSchemas']['roles']['founding-member'] = $founding_member == "true";
     if (!empty($subscriptionExpiry)) {

--- a/postable/admin-member-edit.php
+++ b/postable/admin-member-edit.php
@@ -34,7 +34,7 @@ function prefix_admin_update_member() {
     if (!empty($rfidNumber)) {
         $properties['customSchemas']['roles']['rfid-id'] = $rfidNumber;
     } else {
-        $properties['customSchemas']['roles']['rfid-id'] = NULL;
+        $properties['customSchemas']['roles']['rfid-id'] = null;
     }
     $properties['customSchemas']['roles']['founding-member'] = $founding_member == "true";
     if (!empty($subscriptionExpiry)) {

--- a/postable/admin-member-edit.php
+++ b/postable/admin-member-edit.php
@@ -31,7 +31,11 @@ function prefix_admin_update_member() {
     );
 
     $properties['customSchemas']['Subscription_Management']['Subscription_Type'] = $subscriptionType;
-    $properties['customSchemas']['roles']['rfid-id'] = $rfidNumber;
+    if (!empty($rfidNumber)) {
+        $properties['customSchemas']['roles']['rfid-id'] = $rfidNumber;
+    } else {
+        $properties['customSchemas']['roles']['rfid-id'] = NULL;
+    }
     $properties['customSchemas']['roles']['founding-member'] = $founding_member == "true";
     if (!empty($subscriptionExpiry)) {
         $properties['customSchemas']['Subscription_Management']['Subscription_Expiration'] = $subscriptionExpiry;


### PR DESCRIPTION
This was a little tricky.. G Suite doesn't like us sending in an empty RFID tag. You're supposed to send NULL to delete the value, but that doesn't work either. What I did to fix this is just treat 0 as empty. I updated the UI to treat it this way, so if you submit with an empty RFID tag, it really saves 0 for the user in G suite. But it shows as empty in the UI still.

Fixes #110 