### PR TITLE
Show an error on the member page if not logged in

### DIFF
--- a/front-end-pages/member-page/failure.html
+++ b/front-end-pages/member-page/failure.html
@@ -3,12 +3,14 @@
 </style>
 
 <br>
-<div class="panel panel-danger">
-    <div class="panel-heading">
-        Whoops!
-    </div>
+<div class="container-fluid">
+    <div class="panel panel-danger">
+        <div class="panel-heading">
+            Whoops!
+        </div>
 
-    <div class="panel-body">
-        <p>You must be logged into DecaturMakers to visit this page. Please return to the homepage and log in.</p>
+        <div class="panel-body">
+            <p>You must be logged into DecaturMakers to visit this page. Please return to the homepage and log in.</p>
+        </div>
     </div>
 </div>

--- a/front-end-pages/member-page/failure.html
+++ b/front-end-pages/member-page/failure.html
@@ -1,0 +1,14 @@
+<style type="text/css">
+   body { background: #F2F2F2 !important; } /* PHP doesnt call the file well enough to override Bootstrap */
+</style>
+
+<br>
+<div class="panel panel-danger">
+    <div class="panel-heading">
+        Whoops!
+    </div>
+
+    <div class="panel-body">
+        <p>You must be logged into DecaturMakers to visit this page. Please return to the homepage and log in.</p>
+    </div>
+</div>

--- a/front-end-pages/member-page/member-page.php
+++ b/front-end-pages/member-page/member-page.php
@@ -1,15 +1,15 @@
-<?php 
+<?php
+require_once dirname(__DIR__).'/../resources/GSuiteAPI.php';
 
+get_header();
+
+// Show error if not logged in
 $wp_user = wp_get_current_user();
-
-//redirect if not logged in
-if ($wp_user->ID == 0) {
-    wp_redirect('/login');
-    exit('Redirected logged out user');
+if ($wp_user->ID == 0 || getUser($wp_user->user_email) == NULL) {
+    include 'failure.html';
+    get_footer();
+    exit();
 }
-
-get_header(); 
-
 ?>
 
 <div id="primary" class="content-area">

--- a/resources/GSuiteAPI.php
+++ b/resources/GSuiteAPI.php
@@ -48,7 +48,7 @@ function getUser($email) {
     } catch (Google_Service_Exception $e) {
         $user = NULL;
     }
-    return NULL;
+    return $user;
 }
 
 /**

--- a/resources/GSuiteAPI.php
+++ b/resources/GSuiteAPI.php
@@ -42,7 +42,13 @@ function getUser($email) {
         'projection' => 'custom',
         'customFieldMask' => 'Subscription_Management,roles',
     );
-    return $service->users->get($email, $optParams);
+    $user;
+    try {
+        $user = $service->users->get($email, $optParams);
+    } catch (Google_Service_Exception $e) {
+        $user = NULL;
+    }
+    return NULL;
 }
 
 /**


### PR DESCRIPTION
Instead of redirecting to the wrong login page, shows an error to the user if they are not logged in or if they are logged in with a wordpress account that doesn't correspond to a G Suite account.